### PR TITLE
#6 - 회원가입 요청 비즈니스 로직 tdd로 구현하기

### DIFF
--- a/src/main/java/com/refactoring/refactoringproject/dto/CareerFormat.java
+++ b/src/main/java/com/refactoring/refactoringproject/dto/CareerFormat.java
@@ -1,0 +1,26 @@
+package com.refactoring.refactoringproject.dto;
+
+import com.refactoring.refactoringproject.entity.Career;
+
+public class CareerFormat {
+    public CareerFormat(String company, int months) {
+        this.company = company;
+        this.months = months;
+    }
+
+    public static CareerFormat of(String company, int months) {
+        return new CareerFormat(company, months);
+    }
+
+    public static Career toEntity(CareerFormat dto) {
+        return new Career(
+                null,
+                null,
+                dto.company,
+                dto.months
+        );
+    }
+
+    private String company;
+    private int months;
+}

--- a/src/main/java/com/refactoring/refactoringproject/dto/MemberSignInFormat.java
+++ b/src/main/java/com/refactoring/refactoringproject/dto/MemberSignInFormat.java
@@ -1,0 +1,40 @@
+package com.refactoring.refactoringproject.dto;
+
+import com.refactoring.refactoringproject.entity.Career;
+import com.refactoring.refactoringproject.entity.Member;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class MemberSignInFormat {
+    public MemberSignInFormat() {
+    }
+
+    private MemberSignInFormat(String email, String password, String level, List<CareerFormat> careers) {
+        this.email = email;
+        this.password = password;
+        this.level = level;
+        if (careers != null) this.careers = careers;
+    }
+
+    public static MemberSignInFormat of(String email, String password, String level, List<CareerFormat> careers) {
+        return new MemberSignInFormat(email, password, level, careers);
+    }
+
+    public static Member toEntity(MemberSignInFormat dto) {
+        Member member = new Member(dto.email, dto.password, dto.level);
+        List<Career> careers = dto.careers.stream().map(careerFormat -> CareerFormat.toEntity(careerFormat))
+                .collect(Collectors.toList());
+        careers.forEach(career -> member.addCareer(career));
+
+        return member;
+    }
+
+    private String email;
+    private String password;
+    private String level;
+    private List<CareerFormat> careers = new ArrayList<>();
+}

--- a/src/main/java/com/refactoring/refactoringproject/entity/Career.java
+++ b/src/main/java/com/refactoring/refactoringproject/entity/Career.java
@@ -1,15 +1,29 @@
 package com.refactoring.refactoringproject.entity;
 
+import lombok.Getter;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
 @Table(name = "CAREER")
 public class Career extends BaseEntityTime {
+    public Career() {
+    }
+
+    public Career(Long id, Member member, String company, int months) {
+        this.id = id;
+        this.member = member;
+        this.company = company;
+        this.months = months;
+    }
+
     @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "ID")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID", nullable = false)
     private Member member;
 
@@ -18,4 +32,12 @@ public class Career extends BaseEntityTime {
 
     @Column(name = "MONTHS", nullable = false)
     private int months;
+
+    public void assignMember(Member member) {
+        if (this.member != null) {
+            throw new IllegalArgumentException("You can't change Member of Career which is already assigned.");
+        }
+
+        this.member = member;
+    }
 }

--- a/src/main/java/com/refactoring/refactoringproject/entity/Member.java
+++ b/src/main/java/com/refactoring/refactoringproject/entity/Member.java
@@ -1,13 +1,31 @@
 package com.refactoring.refactoringproject.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
+@Getter
 @Table(name = "MEMBER")
 public class Member extends BaseEntityTime {
+    public Member() {
+    }
+
+    public Member(String id, String password, String level) {
+        this.id = id;
+        this.password = password;
+        this.level = level;
+    }
+
+    public Member(String id, String password, String level, List<Career> careers) {
+        this.id = id;
+        this.password = password;
+        this.level = level;
+        this.careers = careers;
+    }
+
     @Id
     @Column(length = 50)
     private String id;
@@ -17,4 +35,12 @@ public class Member extends BaseEntityTime {
 
     @Column(length = 10, nullable = false)
     private String level;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.MERGE)
+    private List<Career> careers = new ArrayList<>();
+
+    public void addCareer(Career career) {
+        this.careers.add(career);
+        career.assignMember(this);
+    }
 }

--- a/src/main/java/com/refactoring/refactoringproject/service/MemberService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/MemberService.java
@@ -1,0 +1,25 @@
+package com.refactoring.refactoringproject.service;
+
+import com.refactoring.refactoringproject.dto.MemberSignInFormat;
+import com.refactoring.refactoringproject.entity.Member;
+import com.refactoring.refactoringproject.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public void signIn(MemberSignInFormat signInFormat) {
+        if (memberRepository.findById(signInFormat.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("Member already exists with this email: " + signInFormat.getEmail());
+        }
+
+        Member member = MemberSignInFormat.toEntity(signInFormat);
+        Member savedMember = memberRepository.save(member);
+        log.info("Signing In Completed. Member ID: {}", savedMember.getId());
+    }
+}

--- a/src/test/java/com/refactoring/refactoringproject/service/MemberServiceTest.java
+++ b/src/test/java/com/refactoring/refactoringproject/service/MemberServiceTest.java
@@ -1,0 +1,102 @@
+package com.refactoring.refactoringproject.service;
+
+import com.refactoring.refactoringproject.dto.CareerFormat;
+import com.refactoring.refactoringproject.dto.MemberSignInFormat;
+import com.refactoring.refactoringproject.entity.Career;
+import com.refactoring.refactoringproject.entity.Member;
+import com.refactoring.refactoringproject.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("유효한 회원가입 정보(경력 없음)가 제공되면 회원가입에 성공한다.")
+    void givenNormalSignInFormatWithoutCareer_whenSigningIn_thenSuccess() {
+        // given
+        String email = "test@gmail.com";
+        String password = "testpassword1234";
+        String level = "지망생";
+        MemberSignInFormat signInFormat = MemberSignInFormat.of(email, password, level, null);
+
+        // when
+        memberService.signIn(signInFormat);
+
+        // then
+        Optional<Member> resultOptional = memberRepository.findById(email);
+        if (!resultOptional.isPresent()) fail();
+
+        Member result = resultOptional.get();
+        assertThat(result.getId()).isEqualTo(email);
+        assertThat(result.getLevel()).isEqualTo(level);
+        assertThat(result.getPassword()).isEqualTo(password);
+    }
+
+    @Test
+    @DisplayName("유효한 회원가입 정보(경력 있음)가 제공되면 회원가입에 성공한다.")
+    void givenNormalMemberLoginDto_whenSigningIn_thenSuccess() {
+        // given
+        String email = "test@gmail.com";
+        String password = "testpassword1234";
+        String level = "주니어";
+
+        CareerFormat career1 = new CareerFormat("삼성전자 응가부서", 30);
+        CareerFormat career2 = new CareerFormat("네이버 핵폭탄부서", 4);
+
+        MemberSignInFormat signInFormat = MemberSignInFormat.of(email, password, level, List.of(career1, career2));
+
+        // when
+        memberService.signIn(signInFormat);
+
+        // then
+        Optional<Member> resultOptional = memberRepository.findById(email);
+        if (!resultOptional.isPresent()) fail();
+
+        Member result = resultOptional.get();
+
+        assertThat(result.getId()).isEqualTo(email);
+        assertThat(result.getLevel()).isEqualTo(level);
+        assertThat(result.getPassword()).isEqualTo(password);
+
+        List<Career> careers = result.getCareers();
+        assertThat(careers)
+                .extracting(Career::getCompany).containsExactly("삼성전자 응가부서", "네이버 핵폭탄부서");
+        assertThat(careers)
+                .extracting(Career::getMonths).containsExactly(30, 4);
+    }
+
+    @Test
+    @DisplayName("이미 회원가입 한 이메일로 회원가입 하려는 경우 예외가 발생한다.")
+    void givenMemberWithAlreadyExistingId_whenSigningIn_thenThrowsIllegalArgumentException() {
+        // given
+        String email = "test@gmail.com";
+        String password = "testpassword1234";
+        String level = "주니어";
+
+        MemberSignInFormat signInFormat = MemberSignInFormat.of(email, password, level, null);
+        memberService.signIn(signInFormat);
+
+        MemberSignInFormat inValidSignInFormat = MemberSignInFormat.of(email, password, level, null);
+
+        // when
+        assertThrows(IllegalArgumentException.class,
+                () -> memberService.signIn(inValidSignInFormat));
+    }
+}


### PR DESCRIPTION
테스트코드를 먼저 작성하면서 컨트롤러 계층과 서비스 계층의 비즈니스 로직 사이에 어떤 메시지가 오가고, 필요로 하는 값을 어떤 형태로 전달해야 할지 고민해본 후 구현 코드 작성에 들어갔습니다.

컨트롤러 계층에서 엔티티 클래스를 직접 조작하는 것은 유지보수 설계에 악영향을 미칠 수 있기 때문에, 컨트롤러에서는 필요한 값이 들어간 두 개의 DTO(CareerFormat, MemberSignInFormat)을 비즈니스 로직에 전달하도록 하고, 비즈니스 로직 안에서 DTO를 엔티티 객체로 변환한 후 리포지토리에 요청을 보내고 응답을 받는 형태로 구현했습니다.

이 과정에서 엔티티 클래스에도 다소 수정이 일어났습니다. Member 객체에는 적절한 생성자를 추가하고, Member 저장 시 여러 개의 Career를 함께 저장할 수 있도록 Career에 대한 OneToMany 연관관계를 추가한 후 cascadeType.MERGE를 설정했습니다. cascadeType.MERGE에서는 left outer join 쿼리를 무조건 날리게 되므로 성능에 악영향을 줄 수 있는데, cascadeType.PERSIST로 설정할 경우 List에 들어간 Career가 함께 저장되지 않는 문제가 있습니다. 이후 최적화 단계에서 보완해야 할 문제입니다.

엔티티의 값을 바꾸는 도메인 로직의 경우에는 단순히 setter문을 사용하지 않고, addCareer, assginMember 처럼 의도를 비교적 명확히 하는 메서드명과 함께 의도에 적합한 검증 로직을 추가로 넣어두었습니다.

This closes #6