### PR TITLE
#14 - 리팩토링 대상 코드 단건 조회 비즈니스 로직 tdd로 구현하기

### DIFF
--- a/src/main/java/com/refactoring/refactoringproject/dto/RefactoringTodoOrderResponse.java
+++ b/src/main/java/com/refactoring/refactoringproject/dto/RefactoringTodoOrderResponse.java
@@ -1,0 +1,17 @@
+package com.refactoring.refactoringproject.dto;
+
+import com.refactoring.refactoringproject.entity.RefactoringTodoOrder;
+import lombok.Getter;
+
+@Getter
+public class RefactoringTodoOrderResponse {
+    private String content;
+
+    private RefactoringTodoOrderResponse(String content) {
+        this.content = content;
+    }
+
+    public static RefactoringTodoOrderResponse from(RefactoringTodoOrder entity) {
+        return new RefactoringTodoOrderResponse(entity.getContent());
+    }
+}

--- a/src/main/java/com/refactoring/refactoringproject/dto/RefactoringTodoResponse.java
+++ b/src/main/java/com/refactoring/refactoringproject/dto/RefactoringTodoResponse.java
@@ -1,0 +1,48 @@
+package com.refactoring.refactoringproject.dto;
+
+import com.refactoring.refactoringproject.entity.Member;
+import com.refactoring.refactoringproject.entity.RefactoringDone;
+import com.refactoring.refactoringproject.entity.RefactoringTodo;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class RefactoringTodoResponse {
+    public RefactoringTodoResponse(Long id, Member member, String language, String code, String description, RefactoringDone bestPractice, List<RefactoringTodoOrderResponse> orders) {
+        this.id = id;
+        this.member = member;
+        this.language = language;
+        this.code = code;
+        this.description = description;
+        this.bestPractice = bestPractice;
+        this.orders = orders;
+    }
+
+    public static RefactoringTodoResponse of(Long id, Member member, String language, String code, String description, RefactoringDone bestPractice, List<RefactoringTodoOrderResponse> orders) {
+        return new RefactoringTodoResponse(id, member, language, code, description, bestPractice, orders);
+    }
+
+    public static RefactoringTodoResponse from(RefactoringTodo entity) {
+        return new RefactoringTodoResponse(
+                entity.getId(),
+                entity.getMember(),
+                entity.getLanguage(),
+                entity.getCode(),
+                entity.getDescription(),
+                entity.getBestPractice(),
+                entity.getOrders().stream()
+                        .map(order -> RefactoringTodoOrderResponse.from(order))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private Long id;
+    private Member member;
+    private String language;
+    private String code;
+    private String description;
+    private RefactoringDone bestPractice;
+    private List<RefactoringTodoOrderResponse> orders;
+}

--- a/src/main/java/com/refactoring/refactoringproject/entity/RefactoringTodo.java
+++ b/src/main/java/com/refactoring/refactoringproject/entity/RefactoringTodo.java
@@ -33,7 +33,7 @@ public class RefactoringTodo extends BaseEntityTime {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID", nullable = false)
     private Member member;
 
@@ -46,7 +46,7 @@ public class RefactoringTodo extends BaseEntityTime {
     @Column(length = 1000)
     private String description;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BEST_PRACTICE")
     private RefactoringDone bestPractice;
 

--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
@@ -1,6 +1,8 @@
 package com.refactoring.refactoringproject.service;
 
 import com.refactoring.refactoringproject.dto.RefactoringTodoFormat;
+import com.refactoring.refactoringproject.dto.RefactoringTodoOrderResponse;
+import com.refactoring.refactoringproject.dto.RefactoringTodoResponse;
 import com.refactoring.refactoringproject.entity.RefactoringTodo;
 import com.refactoring.refactoringproject.repository.RefactoringTodoRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,15 +10,30 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class RefactoringTodoService {
     private final RefactoringTodoRepository refactoringTodoRepository;
 
-    public void saveRefactoringTodo(RefactoringTodoFormat dto) {
+    public Long saveRefactoringTodo(RefactoringTodoFormat dto) {
         RefactoringTodo refactoringTodo = RefactoringTodoFormat.toEntity(dto);
-        refactoringTodoRepository.save(refactoringTodo);
+        RefactoringTodo savedRefactoringTodo = refactoringTodoRepository.save(refactoringTodo);
         log.info("Saving RefactoringTodo Completed. Article ID: {}", refactoringTodo.getId());
+
+        return savedRefactoringTodo.getId();
+    }
+
+    public RefactoringTodoResponse findOneById(Long savedId) {
+        if (savedId == null) {
+            throw new IllegalArgumentException("you tried to find a RefactoringTodo with NULL id");
+        }
+
+        Optional<RefactoringTodo> resultOptional = refactoringTodoRepository.findById(savedId);
+        RefactoringTodo findRefactoringTodo = resultOptional.orElseThrow(() -> new IllegalArgumentException("there is no RefactoringTodo with id " + savedId));
+
+        return RefactoringTodoResponse.from(findRefactoringTodo);
     }
 }

--- a/src/test/java/com/refactoring/refactoringproject/service/RefactoringTodoServiceTest.java
+++ b/src/test/java/com/refactoring/refactoringproject/service/RefactoringTodoServiceTest.java
@@ -1,9 +1,6 @@
 package com.refactoring.refactoringproject.service;
 
-import com.refactoring.refactoringproject.dto.CareerFormat;
-import com.refactoring.refactoringproject.dto.MemberSignInFormat;
-import com.refactoring.refactoringproject.dto.RefactoringTodoFormat;
-import com.refactoring.refactoringproject.dto.RefactoringTodoOrderFormat;
+import com.refactoring.refactoringproject.dto.*;
 import com.refactoring.refactoringproject.entity.Member;
 import com.refactoring.refactoringproject.entity.RefactoringTodo;
 import com.refactoring.refactoringproject.entity.RefactoringTodoOrder;
@@ -18,8 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.List;
+import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -67,16 +65,16 @@ class RefactoringTodoServiceTest {
         RefactoringTodoFormat format = RefactoringTodoFormat.of(member, language, code, description, List.of(todoOrderFormat1, todoOrderFormat2));
 
         // when
-        refactoringTodoService.saveRefactoringTodo(format);
+        Long savedId = refactoringTodoService.saveRefactoringTodo(format);
 
         em.flush();
         em.clear();
 
         // then
-        List<RefactoringTodo> allResult = refactoringTodoRepository.findAll(); // 1개만 등록했으므로 1개만 조회되어야 한다.
-        assertThat(allResult).hasSize(1);
+        Optional<RefactoringTodo> resultOptional = refactoringTodoRepository.findById(savedId);
 
-        RefactoringTodo result = allResult.get(0);
+        if (!resultOptional.isPresent()) fail("Id에 해당하는 RefactoringTodo가 조회되어야 한다.");
+        RefactoringTodo result = resultOptional.get();
 
         assertThat(result.getMember())
                 .extracting(Member::getId).isEqualTo(member.getId());
@@ -86,6 +84,98 @@ class RefactoringTodoServiceTest {
         assertThat(result.getOrders())
                 .extracting(RefactoringTodoOrder::getContent)
                 .containsExactly("메소드 중복을 없애 주십시오.", "개 소리 좀 안 나게 해라!!!!");
+    }
+
+    @Test
+    @DisplayName("리팩토링 대상 코드 - 게시글 id가 주어지면 id에 해당하는 리팩토링 대상 코드 한 건을 반환한다.")
+    void givenRefactoringTodoId_whenFindOneByGivenId_ThenReturnsOneRefactoringTodo() {
+        // given
+        Long savedId = this.saveRefactoringTodo();
+
+        // when
+        RefactoringTodoResponse response = refactoringTodoService.findOneById(savedId);
+
+        // then
+        assertThat(response.getId()).isEqualTo(savedId);
+        assertThat(response.getMember().getId()).isEqualTo("test@gmail.com");
+        assertThat(response.getLanguage()).isEqualTo("JAVA");
+        assertThat(response.getCode()).isEqualTo(
+                "    private String signInMember() {\n" +
+                        "        String email = \"test@gmail.com\";\n" +
+                        "        String password = \"testpassword1234\";\n" +
+                        "        String level = \"주니어\";\n" +
+                        "\n" +
+                        "        CareerFormat career1 = new CareerFormat(\"삼성전자 응가부서\", 30);\n" +
+                        "        CareerFormat career2 = new CareerFormat(\"네이버 핵폭탄부서\", 4);\n" +
+                        "\n" +
+                        "        MemberSignInFormat signInFormat = MemberSignInFormat.of(email, password, level, List.of(career1, career2));\n" +
+                        "\n" +
+                        "        memberService.signIn(signInFormat);\n" +
+                        "\n" +
+                        "        return email;\n" +
+                        "    }"
+        );
+        assertThat(response.getDescription()).isEqualTo("유효한 새 게시글이 제공되면 글이 정상적으로 등록된다.");
+        assertThat(response.getBestPractice()).isNull(); // TODO: BestPractice 구현 후 추가
+        assertThat(response.getOrders())
+                .extracting(RefactoringTodoOrderResponse::getContent)
+                .containsExactly("메소드 중복을 없애 주십시오.", "개 소리 좀 안 나게 해라!!!!");
+    }
+
+    @Test
+    @DisplayName("리팩토링 대상 코드 - 존재하지 않는 게시글 id로 리팩토링 대상 코드를 조회하려 시도하면 예외를 반환한다.")
+    void givenNonExistingRefactoringTodoId_whenFindOneByGivenId_ThenThrowsException() {
+        // given
+        Long savedId = -1L;
+
+        // when & then
+        assertThatThrownBy(() -> refactoringTodoService.findOneById(savedId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("there is no RefactoringTodo with id -1");
+    }
+
+    @Test
+    @DisplayName("리팩토링 대상 코드 - 존재하지 않는 게시글 id로 리팩토링 대상 코드를 조회하려 시도하면 예외를 반환한다.")
+    void givenNullId_whenFindOneByGivenId_ThenThrowsException() {
+        // given
+        Long savedId = null;
+
+        // when & then
+        assertThatThrownBy(() -> refactoringTodoService.findOneById(savedId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("you tried to find a RefactoringTodo with NULL id");
+    }
+
+    private Long saveRefactoringTodo() {
+        Member member = this.signInMember();
+
+        String language = "JAVA";
+        String code = "    private String signInMember() {\n" +
+                "        String email = \"test@gmail.com\";\n" +
+                "        String password = \"testpassword1234\";\n" +
+                "        String level = \"주니어\";\n" +
+                "\n" +
+                "        CareerFormat career1 = new CareerFormat(\"삼성전자 응가부서\", 30);\n" +
+                "        CareerFormat career2 = new CareerFormat(\"네이버 핵폭탄부서\", 4);\n" +
+                "\n" +
+                "        MemberSignInFormat signInFormat = MemberSignInFormat.of(email, password, level, List.of(career1, career2));\n" +
+                "\n" +
+                "        memberService.signIn(signInFormat);\n" +
+                "\n" +
+                "        return email;\n" +
+                "    }";
+        String description = "유효한 새 게시글이 제공되면 글이 정상적으로 등록된다.";
+        RefactoringTodoOrderFormat todoOrderFormat1 = RefactoringTodoOrderFormat.of("메소드 중복을 없애 주십시오.");
+        RefactoringTodoOrderFormat todoOrderFormat2 = RefactoringTodoOrderFormat.of("개 소리 좀 안 나게 해라!!!!");
+
+        RefactoringTodoFormat format = RefactoringTodoFormat.of(member, language, code, description, List.of(todoOrderFormat1, todoOrderFormat2));
+
+        Long savedId = refactoringTodoService.saveRefactoringTodo(format);
+
+        em.flush();
+        em.clear();
+
+        return savedId;
     }
 
     private Member signInMember() {


### PR DESCRIPTION
id를 이용해 RefactoringTodo 한 건을 조회하는 로직은 RefactoringTodoRepository의 findById()를 컨트롤러에서 곧바로 사용할 수도 있지만, 그럴 경우 컨트롤러 계층에서 RefactoringTodo 엔티티 클래스를 조작할 수 있게 되기 때문에 비즈니스 로직에서 RefactorungTodo를 조회한 후 적절한 Dto(RefactoringTodoresponse와 RefactoringTodoOrderResponse)로 바꾸어 컨트롤러에 반환하도록 테스트를 작성하고 구현했습니다.

이 과정에서 엔티티 클래스에도 다소 수정이 있었는데,
RefactoringTodo에서 FetchType.EAGER로 기본 설정된 연관관계에 대해 FetchType.LAZY를 설정해 지연로딩이 이루어지도록 설정했습니다. 지연 로딩이 좋을지 즉시 로딩이 좋을지는 최적화 단계에서 성능 테스트 후에 결정하기로 합니다.

+ 보통 게시글을 저장한 후에 해당 게시글의 상세보기 화면으로 이동하는 것이 일반적이기 때문에, RefactoringTodo 저장 로직을 완료한 클라이언트 측에서 저장된 게시글의 id를 이용해 추가작업을 할 수 있도록 RefactoringTodoService의 saveRefactoringTodo의 반환값을 void에서 게시글 id를 반환하도록 테스트를 고친 후 구현 코드에 반영했습니다. 이 작업은 이슈 #15 에 해당합니다.

This closes #14 
This closes #15 