### PR TITLE
#13 - 리팩토링 대상 코드 삭제 비즈니스 로직 tdd로 구현하기

### DIFF
--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
@@ -8,6 +8,7 @@ import com.refactoring.refactoringproject.repository.RefactoringTodoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -32,8 +33,17 @@ public class RefactoringTodoService {
         }
 
         Optional<RefactoringTodo> resultOptional = refactoringTodoRepository.findById(savedId);
-        RefactoringTodo findRefactoringTodo = resultOptional.orElseThrow(() -> new IllegalArgumentException("there is no RefactoringTodo with id " + savedId));
-
+        RefactoringTodo findRefactoringTodo = resultOptional.orElseThrow(() -> new EmptyResultDataAccessException("there is no RefactoringTodo with id " + savedId, 1));
         return RefactoringTodoResponse.from(findRefactoringTodo);
+    }
+
+    public void deleteOneById(Long savedId) {
+        if (savedId == null) {
+            throw new IllegalArgumentException("you tried to find a RefactoringTodo with NULL id");
+        }
+
+        refactoringTodoRepository.deleteById(savedId);
+
+        log.info("Deleting RefactoringTodo Completed. Article ID: {}", savedId);
     }
 }

--- a/src/test/java/com/refactoring/refactoringproject/service/RefactoringTodoServiceTest.java
+++ b/src/test/java/com/refactoring/refactoringproject/service/RefactoringTodoServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -130,18 +131,56 @@ class RefactoringTodoServiceTest {
 
         // when & then
         assertThatThrownBy(() -> refactoringTodoService.findOneById(savedId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(EmptyResultDataAccessException.class)
                 .hasMessage("there is no RefactoringTodo with id -1");
     }
 
     @Test
-    @DisplayName("리팩토링 대상 코드 - 존재하지 않는 게시글 id로 리팩토링 대상 코드를 조회하려 시도하면 예외를 반환한다.")
+    @DisplayName("리팩토링 대상 코드 - null id로 리팩토링 대상 코드를 조회하려 시도하면 예외를 반환한다.")
     void givenNullId_whenFindOneByGivenId_ThenThrowsException() {
         // given
         Long savedId = null;
 
         // when & then
         assertThatThrownBy(() -> refactoringTodoService.findOneById(savedId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("you tried to find a RefactoringTodo with NULL id");
+    }
+
+    @Test
+    @DisplayName("리팩토링 대상 코드 - 게시글 id가 주어지면 id에 해당하는 리팩토링 대상 코드 한 건을 삭제한다.")
+    void givenRefactoringTodoId_whenDeleteOneByGivenId_ThenSuccess() {
+        // given
+        Long savedId = this.saveRefactoringTodo();
+
+        // when
+        refactoringTodoService.deleteOneById(savedId);
+
+        // then
+        assertThatThrownBy(() -> refactoringTodoService.findOneById(savedId))
+                .isInstanceOf(EmptyResultDataAccessException.class)
+                .hasMessage("there is no RefactoringTodo with id " + savedId);
+    }
+
+    @Test
+    @DisplayName("리팩토링 대상 코드 - 존재하지 않는 게시글 id로 리팩토링 대상 코드를 삭제 시도하면 예외를 반환한다.")
+    void givenNonExistingRefactoringTodoId_whenDeleteOneByGivenId_ThenThrowsException() {
+        // given
+        Long savedId = -1L;
+
+        // when & then
+        assertThatThrownBy(() -> refactoringTodoService.deleteOneById(savedId))
+                .isInstanceOf(EmptyResultDataAccessException.class);
+    }
+
+    @Test
+    @DisplayName("리팩토링 대상 코드 - null id로 리팩토링 대상 코드를 삭제 시도하면 예외를 반환한다.")
+    void givenNullId_whenDeleteOneByGivenId_ThenThrowsException() {
+        // given
+        Long savedId = null;
+
+        // when & then
+        assertThatThrownBy(() -> refactoringTodoService.deleteOneById(savedId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("you tried to find a RefactoringTodo with NULL id");
     }


### PR DESCRIPTION
(실제 서비스 환경에서는 DB에서 삭제하는 것보다 특정 상태값을 바꾸어 프론트엔드에 전달하지 않도록 하고 DB에는 남겨놓도록 하고 있기 때문에, 현재는 Repository의 delete를 사용하지만 추후 개선할 예정입니다.)

파라미터로 주어진 리팩토링 대상 코드 id에 대응하는 리팩토링 대상 코드를 삭제하는 비즈니스 로직을 tdd로 테스트함과 동시에 구현했습니다.

존재하지 않는 아이디를 사용해 삭제 시도를 하는 경우 DB에서 예외가 발생하고, 스프링 프레임워크에서 DB 예외를 스프링 프레임워크에서 제공하는 언체크 예외로 변환합니다. 해당 사항도 테스트를 통해 체크하였습니다.

This closes #13 