### PR TITLE
#18 - 리팩토링 대상 코드 목록 조회 비즈니스 로직 tdd로 구현하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,intellij+all,java,gradle
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
+
+	//Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
@@ -31,4 +38,9 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//Querydsl 추가, 자동 생성된 Q클래스 gradle clean으로 제거
+clean {
+	delete file('src/main/generated')
 }

--- a/src/main/java/com/refactoring/refactoringproject/dto/RefactoringTodoResponse.java
+++ b/src/main/java/com/refactoring/refactoringproject/dto/RefactoringTodoResponse.java
@@ -1,8 +1,10 @@
 package com.refactoring.refactoringproject.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.refactoring.refactoringproject.entity.Member;
 import com.refactoring.refactoringproject.entity.RefactoringDone;
 import com.refactoring.refactoringproject.entity.RefactoringTodo;
+import com.refactoring.refactoringproject.entity.RefactoringTodoOrder;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -25,7 +27,18 @@ public class RefactoringTodoResponse {
         this.modifiedAt = modifiedAt;
     }
 
-    public static RefactoringTodoResponse of(Long id, Member member, String language, String code, String description, RefactoringDone bestPractice, List<RefactoringTodoOrderResponse> orders, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    @QueryProjection
+    public RefactoringTodoResponse(Long id, String language, String code, String description, Long favoriteCount, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.language = language;
+        this.code = code;
+        this.description = description;
+        this.favoriteCount = favoriteCount;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static RefactoringTodoResponse of(Long id, Member member, String language, String code, String description, RefactoringDone bestPractice, List<RefactoringTodoOrderResponse> orders, int favoriteCount, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         return new RefactoringTodoResponse(id, member, language, code, description, bestPractice, orders, createdAt, modifiedAt);
     }
 
@@ -52,6 +65,9 @@ public class RefactoringTodoResponse {
     private String description;
     private RefactoringDone bestPractice;
     private List<RefactoringTodoOrderResponse> orders;
+
+    private Long favoriteCount;
+    // 해당 RefactoringTodo를 즐겨찾기 한 사용자의 숫자
 
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;

--- a/src/main/java/com/refactoring/refactoringproject/entity/RefactoringTodo.java
+++ b/src/main/java/com/refactoring/refactoringproject/entity/RefactoringTodo.java
@@ -53,6 +53,9 @@ public class RefactoringTodo extends BaseEntityTime {
     @OneToMany(mappedBy = "refactoringTodo", cascade = CascadeType.PERSIST)
     private List<RefactoringTodoOrder> orders = new ArrayList<>();
 
+    @OneToMany(mappedBy = "refactoringTodo")
+    private List<Favorite> favorites = new ArrayList<>();
+
     public void addRefactoringOrder(RefactoringTodoOrder order) {
         this.orders.add(order);
         order.assignRefactoringTodo(this);

--- a/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoRepository.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefactoringTodoRepository extends JpaRepository<RefactoringTodo, Long> {
+public interface RefactoringTodoRepository extends JpaRepository<RefactoringTodo, Long>, RefactoringTodoSearchRepository {
     @Override
     @EntityGraph(attributePaths = "orders")
     Page<RefactoringTodo> findAll(Pageable pageable);

--- a/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoRepositoryImpl.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.refactoring.refactoringproject.repository;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.refactoring.refactoringproject.dto.QRefactoringTodoResponse;
+import com.refactoring.refactoringproject.dto.RefactoringTodoResponse;
+import com.refactoring.refactoringproject.entity.RefactoringTodo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import javax.persistence.EntityManager;
+
+import static com.refactoring.refactoringproject.entity.QFavorite.favorite;
+import static com.refactoring.refactoringproject.entity.QRefactoringTodo.refactoringTodo;
+
+public class RefactoringTodoRepositoryImpl implements RefactoringTodoSearchRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public RefactoringTodoRepositoryImpl(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<RefactoringTodoResponse> findListWithFavoriteCount(Pageable pageable) {
+        JPAQuery<RefactoringTodoResponse> query = queryFactory
+                .select(new QRefactoringTodoResponse(
+                        refactoringTodo.id,
+                        refactoringTodo.language,
+                        refactoringTodo.code,
+                        refactoringTodo.description,
+                        ExpressionUtils.as(countFavorites(), "favoriteCount"),
+                        refactoringTodo.createdAt,
+                        refactoringTodo.modifiedAt
+                ))
+                .from(refactoringTodo)
+                .innerJoin(refactoringTodo.favorites, favorite);
+
+        for (Sort.Order order : pageable.getSort()) {
+            query.orderBy(
+                    new OrderSpecifier<>(
+                            order.isAscending() ? Order.ASC : Order.DESC, Expressions.stringPath("favoriteCount")
+                    )
+            );
+        }
+
+        query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+
+        return new PageImpl<>(query.fetch());
+    }
+
+    private JPQLQuery<Long> countFavorites() {
+        JPQLQuery<Long> countFavorites = JPAExpressions
+                .select(favorite.count())
+                .from(favorite)
+                .where(favorite.refactoringTodo.id.eq(refactoringTodo.id))
+                .groupBy(favorite.refactoringTodo);
+        return countFavorites;
+    }
+
+    @Override
+    public RefactoringTodo testQuery() {
+        return queryFactory.selectFrom(refactoringTodo).fetchFirst();
+    }
+}

--- a/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoRepositoryImpl.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoRepositoryImpl.java
@@ -43,13 +43,12 @@ public class RefactoringTodoRepositoryImpl implements RefactoringTodoSearchRepos
                         refactoringTodo.createdAt,
                         refactoringTodo.modifiedAt
                 ))
-                .from(refactoringTodo)
-                .innerJoin(refactoringTodo.favorites, favorite);
+                .from(refactoringTodo);
 
         for (Sort.Order order : pageable.getSort()) {
             query.orderBy(
                     new OrderSpecifier<>(
-                            order.isAscending() ? Order.ASC : Order.DESC, Expressions.stringPath("favoriteCount")
+                            order.isAscending() ? Order.ASC : Order.DESC, Expressions.stringPath(order.getProperty())
                     )
             );
         }
@@ -58,7 +57,6 @@ public class RefactoringTodoRepositoryImpl implements RefactoringTodoSearchRepos
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 
-
         return new PageImpl<>(query.fetch());
     }
 
@@ -66,13 +64,7 @@ public class RefactoringTodoRepositoryImpl implements RefactoringTodoSearchRepos
         JPQLQuery<Long> countFavorites = JPAExpressions
                 .select(favorite.count())
                 .from(favorite)
-                .where(favorite.refactoringTodo.id.eq(refactoringTodo.id))
-                .groupBy(favorite.refactoringTodo);
+                .where(favorite.refactoringTodo.id.eq(refactoringTodo.id));
         return countFavorites;
-    }
-
-    @Override
-    public RefactoringTodo testQuery() {
-        return queryFactory.selectFrom(refactoringTodo).fetchFirst();
     }
 }

--- a/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoSearchRepository.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoSearchRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.domain.Pageable;
 
 public interface RefactoringTodoSearchRepository {
     Page<RefactoringTodoResponse> findListWithFavoriteCount(Pageable pageable);
-
-    RefactoringTodo testQuery();
 }

--- a/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoSearchRepository.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/RefactoringTodoSearchRepository.java
@@ -1,0 +1,12 @@
+package com.refactoring.refactoringproject.repository;
+
+import com.refactoring.refactoringproject.dto.RefactoringTodoResponse;
+import com.refactoring.refactoringproject.entity.RefactoringTodo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RefactoringTodoSearchRepository {
+    Page<RefactoringTodoResponse> findListWithFavoriteCount(Pageable pageable);
+
+    RefactoringTodo testQuery();
+}

--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
@@ -51,13 +51,6 @@ public class RefactoringTodoService {
     }
 
     public Page<RefactoringTodoResponse> findList(Pageable pageable) {
-        Sort sort = pageable.getSort();
-        for (Sort.Order order : sort) {
-            if (order.getProperty().equals("favoriteCount")) {
-                return refactoringTodoRepository.findListWithFavoriteCount(pageable);
-            }
-        }
-        Page<RefactoringTodo> findList = refactoringTodoRepository.findAll(pageable);
-        return findList.map(refactoringTodo -> RefactoringTodoResponse.from(refactoringTodo));
+        return refactoringTodoRepository.findListWithFavoriteCount(pageable);
     }
 }

--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringTodoService.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -50,6 +51,12 @@ public class RefactoringTodoService {
     }
 
     public Page<RefactoringTodoResponse> findList(Pageable pageable) {
+        Sort sort = pageable.getSort();
+        for (Sort.Order order : sort) {
+            if (order.getProperty().equals("favoriteCount")) {
+                return refactoringTodoRepository.findListWithFavoriteCount(pageable);
+            }
+        }
         Page<RefactoringTodo> findList = refactoringTodoRepository.findAll(pageable);
         return findList.map(refactoringTodo -> RefactoringTodoResponse.from(refactoringTodo));
     }

--- a/src/test/java/com/refactoring/refactoringproject/service/MemberServiceTest.java
+++ b/src/test/java/com/refactoring/refactoringproject/service/MemberServiceTest.java
@@ -149,7 +149,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("자신이 작성한 리팩토링 대상 코드 게시글을 즐겨찾기 등록할 수 없다.")
+    @DisplayName("이미 즐겨찾기 등록한 리팩토링 대상 코드 게시글을 중복으로 즐겨찾기 등록할 수 없다.")
     void givenMemberAndOneRefactoringTodoAlreadyAssigned_whenRequestingFavorite_thenThrowsException() {
         // given
         Member member = this.signInMemberWithIdCondition("test@gmail.com");

--- a/src/test/java/com/refactoring/refactoringproject/service/RefactoringTodoServiceTest.java
+++ b/src/test/java/com/refactoring/refactoringproject/service/RefactoringTodoServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -211,20 +212,51 @@ class RefactoringTodoServiceTest {
         // then
         assertThat(resultList).hasSize(10);
 
-        List<RefactoringTodoResponse> resultContentList = resultList.getContent();
-        for (int i = 0; i < 9; i++) {
-            assertThat(resultContentList.get(i).getCreatedAt())
-                    .isAfter(resultContentList.get(i + 1).getCreatedAt());
+        Iterator<RefactoringTodoResponse> iterator = resultList.iterator();
+        RefactoringTodoResponse next = null;
+        while (iterator.hasNext()) {
+            if (next == null) next = iterator.next();
+            RefactoringTodoResponse next2 = iterator.next();
+            assertThat(next.getCreatedAt())
+                    .isAfter(next2.getCreatedAt());
+            next = next2;
         }
+    }
 
-        for (RefactoringTodoResponse refactoringTodoResponse : resultContentList) {
-            System.out.println("refactoringTodoResponse = " + refactoringTodoResponse);
+    @Test
+    @DisplayName("리팩토링 대상 코드 - 최근에 작성한 작성일 순서대로 오름차순 정렬 옵션을 주면 리팩토링 대상 코드 10개를 해당 옵션에 맞게 정렬하여 조회한다.")
+    void givenSortingOptionWithCreatedDateASC_whenFindRefactoringTodoList_thenReturnsListWithGivenConditions() {
+        // given
+        Member member = this.signInMember();
+        for (int i = 0; i < 100; i++) {
+            saveRefactoringTodoWithMemberCondition(member);
+        }
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdAt"));
+        /*
+        * 컨트롤러에서 @PageableDefault(size = 10, sort = “createdAt”, direction = Sort.Direction.DESC) Pageable pageable)
+        * 옵션의 PageRequest가 들어올 예정이다.
+        * */
+
+        // when
+        Page<RefactoringTodoResponse> resultList = refactoringTodoService.findList(pageable);
+
+        // then
+        assertThat(resultList).hasSize(10);
+
+        Iterator<RefactoringTodoResponse> iterator = resultList.iterator();
+        RefactoringTodoResponse next = null;
+        while (iterator.hasNext()) {
+            if (next == null) next = iterator.next();
+            RefactoringTodoResponse next2 = iterator.next();
+            assertThat(next.getCreatedAt())
+                    .isBefore(next2.getCreatedAt());
+            next = next2;
         }
     }
 
     @Test
     @DisplayName("리팩토링 대상 코드 - 즐겨찾기 수가 많은 순서대로 내림차순 정렬 옵션을 주면 리팩토링 대상 코드 10개를 해당 옵션에 맞게 정렬하여 조회한다.")
-    void givenSortingOptionWithNumberOfFavorites_whenFindRefactoringTodoList_thenReturnsListWithGivenConditions() {
+    void givenSortingOptionWithNumberOfFavoritesDESC_whenFindRefactoringTodoList_thenReturnsListWithGivenConditions() {
         // given
         Member member = this.signInMember();
 
@@ -232,7 +264,7 @@ class RefactoringTodoServiceTest {
             this.signInMemberWithEmailCondition("test" + i + "@gmail.com");
         }
 
-        for (int i = 0; i < 50; i++) {
+        for (int i = 0; i < 30; i++) {
             Long savedRefactoringTodo = saveRefactoringTodoWithMemberCondition(member);
 
             int random = (int) (Math.random() * 50) + 1;
@@ -255,15 +287,62 @@ class RefactoringTodoServiceTest {
 
         // then
         assertThat(resultList).hasSize(10);
+        Iterator<RefactoringTodoResponse> iterator = resultList.iterator();
+
+        RefactoringTodoResponse next = null;
+        while (iterator.hasNext()) {
+            if (next == null) next = iterator.next();
+            RefactoringTodoResponse next2 = iterator.next();
+            assertThat(next.getFavoriteCount())
+                    .isGreaterThanOrEqualTo(next2.getFavoriteCount());
+            next = next2;
+        }
     }
 
     @Test
-    @DisplayName("테스트")
-    void test() {
-        this.saveMemberAndSaveRefactoringTodo();
+    @DisplayName("리팩토링 대상 코드 - 즐겨찾기 수가 많은 순서대로 오름차순 정렬 옵션을 주면 리팩토링 대상 코드 10개를 해당 옵션에 맞게 정렬하여 조회한다.")
+    void givenSortingOptionWithNumberOfFavoritesASC_whenFindRefactoringTodoList_thenReturnsListWithGivenConditions() {
+        // given
+        Member member = this.signInMember();
 
-        RefactoringTodo refactoringTodo = refactoringTodoRepository.testQuery();
-        assertThat(refactoringTodo).isNotNull();
+        for (int i = 0; i < 50; i++) {
+            this.signInMemberWithEmailCondition("test" + i + "@gmail.com");
+        }
+
+        for (int i = 0; i < 30; i++) {
+            Long savedRefactoringTodo = saveRefactoringTodoWithMemberCondition(member);
+
+            int random = (int) (Math.random() * 50) + 1;
+            for (int j = 0; j < random; j++) {
+                Member follower = memberRepository.findById("test" + j + "@gmail.com").get();
+                memberService.assignFavorite(savedRefactoringTodo, follower);
+            }
+            /*
+            * 1~50 명 사이의 회원이 해당 리팩토링 대상 코드를 즐겨찾기 한다.
+            * */
+        }
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.ASC, "favoriteCount");
+        /*
+        * 컨트롤러에서 즐겨찾기 순 / 내림차순 옵션의 PageRequest가 들어올 예정이다.
+        * */
+
+        // when
+        Page<RefactoringTodoResponse> resultList = refactoringTodoService.findList(pageable);
+
+        // then
+        assertThat(resultList).hasSize(10);
+        Iterator<RefactoringTodoResponse> iterator = resultList.iterator();
+
+        RefactoringTodoResponse next = null;
+        while (iterator.hasNext()) {
+            if (next == null) next = iterator.next();
+            System.out.println("next = " + next);
+            RefactoringTodoResponse next2 = iterator.next();
+            assertThat(next.getFavoriteCount())
+                    .isLessThanOrEqualTo(next2.getFavoriteCount());
+            next = next2;
+        }
     }
 
     /*


### PR DESCRIPTION
Spring Data Jpa로 해결하기엔 복잡한 리포지토리 쿼리를 편하게 구현하기 위해 QueryDsl 라이브러리를 추가하고
주어진 정렬 옵션에 따라 리팩토링 대상 코드 목록을 조회하는 비즈니스 로직을 tdd로 테스트하고 구현했습니다.
각 커밋의 상세 내용은 커밋 메시지에 기재되어 있습니다.