### PR TITLE
#23 - AWS에 프로젝트 배포하기

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,7 @@
-spring.datasource.url=jdbc:h2:tcp://localhost/~/toyproject
-spring.datasource.username=sa
-spring.datasource.password=
-spring.datasource.driver-class-name=org.h2.Driver
+#spring.datasource.url=jdbc:h2:tcp://localhost/~/toyproject
+#spring.datasource.username=sa
+#spring.datasource.password=
+#spring.datasource.driver-class-name=org.h2.Driver
 
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
원래 테스트 코드 실행 시 사용하는 데이터베이스로 H2 데이터베이스에서 url을 지정해서 사용했는데,  aws ec2에 배포하기 전 테스트를 실행할 때에는 이 설정때문에 모든 테스트가 깨집니다. 이를 방지하기 위해 테스트 코드 실행용 데이터베이스를 테스트가 실행될 때 인메모리에서 생성하고, 테스트가 종료되었을 때 자동으로 삭제되도록 하여 테스트가 원활하게 성공하도록 개선할 예정입니다.

This closes #23 