### PR TITLE
#25 - aws RDS에 애플리케이션 데이터베이스 연결하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.profiles.include=real-db


### PR DESCRIPTION
AWS RDS의 종류로 MariaDB를 사용하기로 했으므로, 라이브러리 의존성 설정에서 Mysql을 제거한 후 MariaDB를 추가합니다. 그리고 application.properties에서 real-db라는 데이터베이스 설정파일을 읽어올 수 있도록 설정합니다. 데이터베이스 설정파일인 real-db 파일은 깃허브에 노출되면 안되기 때문에 ec2 내부에 설정파일을 만들어 사용하도록 만들 예정입니다.