### PR TITLE
#25 - 서버 Private Address, 포트 번호 지정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.profiles.include=real-db
+server.address=172.31.5.141
+server.port=8080


### PR DESCRIPTION
EC2에 성공적으로 배포한 후에도 Connection Refused라며 접근이 안되고 있습니다. 구글링으로 검색해본 결과 스프링 부트의 설정 파일에 Private Address 값과 Port 번호를 제대로 명시해주어야 한다는 글이 있어 시험해보고자 합니다.