### PR TITLE
#30 - S3와 연동하기 위한 travis.yml 변경

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,23 @@ cache:
 # master 브랜치에 푸시되었을 때 수행하는 명령어
 script: "./gradlew clean build"
 
+before_deploy:
+  - zip -r refactoring-project *
+  - mkdir -p deploy
+  - mv refactoring-project.zip deploy/refactoring-project.zip
+
+deploy:
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY
+    secret_access_key: $AWS_SECRET_KEY
+
+    bucket: refactoring-project-build
+    region: ap-northeast-2
+    skip_cleanup: true
+    acl: private
+    local_dir: deploy
+    wait-until-deployed: true
+
 # CI 실행 완료 시 보낼 알람
 notifications:
   email:


### PR DESCRIPTION
배포에 사용되는 CodeDeploy는 파일을 저장하는 기능이 없기 때문에, Travis에서 CI를 마친 후 S3에 파일을 저장하는 작업을 해야 합니다.