### PR TITLE
#30 - S3 접근을 허용할 브랜치 설정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ deploy:
     acl: private
     local_dir: deploy
     wait-until-deployed: true
+    on: 
+      branch: main
 
 # CI 실행 완료 시 보낼 알람
 notifications:


### PR DESCRIPTION
S3으로의 접근을 실행할 브랜치를 설정해주지 않아, CI 진행시 'Skipping a deployment with the s3 provider because this branch is not permitted: main' 에러가 발생합니다. travis.yml에 main 브랜치를 허용하도록 설정파일을 변경합니다.