### PR TITLE
#30 - CodeDeploy와 연동하기 위한 설정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,20 @@ deploy:
     on: 
       branch: main
 
+  - provider: codedeploy
+    access_key_id: $AWS_ACCESS_KEY
+    secret_access_key: $AWS_SECRET_KEY
+
+    bucket: refactoring-project-build
+    key: refactoring-project.zip
+
+    bundle_type: zip
+    application: refactoring-project
+    deployment_group: refactoring-project-group
+
+    region: ap-northeast-2
+    wait-until-deployed: true
+
 # CI 실행 완료 시 보낼 알람
 notifications:
   email:


### PR DESCRIPTION
Travis CI에서 빌드한 파일을 s3에 업로드한 후, codeDeploy에 s3의 파일 위치를 알려줌과 동시에 그 파일로 배포를 진행하도록 설정 파일을 작성합니다.