### PR TITLE
#30 - codeDeploy 작업을 허용할 브랜치 설정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ deploy:
     deployment_group: refactoring-project-group
     region: ap-northeast-2
     wait-until-deployed: true
+    on:
+      branch: main
 
 # CI 실행 완료 시 보낼 알람
 notifications:


### PR DESCRIPTION
드디어 Travis ci가 codeDeploy를 인식합니다!!
'Skipping a deployment with the codedeploy provider because this branch is not permitted: main' 라는 로그가 출력되며 main 브랜치의 권한이 없다는 것을 알게되었으므로 main 브랜치에서 푸시가 일어날 때 codeDeploy 관련 작업을 허용하도록 설정 파일을 수정해줍니다.