### PR TITLE
#46 - deploy.sh의 잘못된 디렉토리 경로 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,7 +9,7 @@ cp $REPOSITORY/zip/*.jar $REPOSITORY/
 
 echo "> 현재 구동중인 애플리케이션 pid 확인"
 
-CURRENT_PID=$(pgrep -fl crawler-service | grep java | awk '{print $1}')
+CURRENT_PID=$(pgrep -fl refactoring-project | grep jar | awk '{print $1}')
 
 echo "현재 구동중인 어플리케이션 pid: $CURRENT_PID"
 
@@ -35,4 +35,4 @@ echo "> $JAR_NAME 실행"
 
 nohup java -jar \
         -Dspring.config.location=classpath:/application.properties,/home/ec2-user/app/application-real-db.properties \
-        $REPOSITORY/$JAR_NAME 2>&1 &
+        $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &


### PR DESCRIPTION
codedeploy-logs 파일에서 오류 원인을 찾아보려 파일을 열었더니 'Unable to access jarfile /home/ec2-user/app/step2//home/ec2-user/app/step2/refactoring-project-0.0.1-SNAPSHOT-plain.jar' 라는 로그가 기록되어 있습니다. deploy.sh 파일에서 디렉토리 경로를 잘못 적어놓아 생긴 문제로 판단하고 경로를 수정합니다.