### PR TITLE
#46 - plain jar가 생성되지 못하도록 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,3 +44,7 @@ tasks.named('test') {
 clean {
 	delete file('src/main/generated')
 }
+
+jar {
+	enabled = false
+}


### PR DESCRIPTION
스프링 부트에서 gradle로 빌드할 때 파일이 두 개가 생성됩니다. 하나는 executable jar, 또 하나는 plain jar입니다.

plain jar는 어플리케이션 실행에 필요한 모든 의존성을 포함하지 않고, 작성된 소스코드의 클래스 파일과 리소스 파일만 포함하는데, 따라서 spring 관련 의존성이 빠져있는 plain jar를 java -jar 명령어로 실행하려 하면 'no main manifest attrubute in' 에러가 발생합니다.

build.gradle 파일에 적절한 코드를 추가하여 plain.jar 파일이 생성되지 못하게 막으려 합니다.