### PR TITLE
#46 - application.properties의 server.address 값 제거

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.profiles.include=real-db
-server.address=172.31.5.141
+#server.address=172.31.5.141
 server.port=8080


### PR DESCRIPTION
nginx에서 서버 내부의 8080 포트로 이동하려 할 때 111: Connection refused 에러가 나고 있는데, 스프링 부트 설정에서 server.address 값 때문에 접근하지 못하는 건가 싶어 해당 코드를 주석처리 했습니다.