### PR TITLE
#52 - 리팩토링 된 코드 등록 실패 로직 tdd로 테스트하고 구현하기

### DIFF
--- a/src/main/java/com/refactoring/refactoringproject/dto/RefactoringDoneFormat.java
+++ b/src/main/java/com/refactoring/refactoringproject/dto/RefactoringDoneFormat.java
@@ -5,9 +5,15 @@ import com.refactoring.refactoringproject.entity.RefactoringDone;
 import com.refactoring.refactoringproject.entity.RefactoringTodo;
 import com.refactoring.refactoringproject.service.RefactoringTodoService;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 @Getter
+@Setter
 public class RefactoringDoneFormat {
 
     private RefactoringDoneFormat(Long refactoringTodoId, Member member, String code, String description) {
@@ -20,9 +26,15 @@ public class RefactoringDoneFormat {
     @Autowired
     private RefactoringTodoService refactoringTodoService;
 
+    @NotNull
     private Long refactoringTodoId;
+    @NotNull
     private Member member;
+    @Size(max = 10000)
+    @NotEmpty
     private String code;
+
+    @Size(max = 1000)
     private String description;
 
     public static RefactoringDoneFormat of(Long refactoringTodoId, Member member, String code, String description) {

--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringDoneService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringDoneService.java
@@ -20,7 +20,7 @@ public class RefactoringDoneService {
 
     public Long saveRefactoringDone(RefactoringDoneFormat format) {
         Optional<RefactoringTodo> refactoringTodoOptional = refactoringTodoRepository.findById(format.getRefactoringTodoId());
-        if (refactoringTodoOptional.isEmpty()) throw new IllegalArgumentException();
+        if (refactoringTodoOptional.isEmpty()) throw new IllegalArgumentException("you tried to post a RefactoringDone of RefactoringTodo which is not existing");
         RefactoringTodo refactoringTodo = refactoringTodoOptional.get();
 
         RefactoringDone refactoringDone = RefactoringDoneFormat.toEntity(refactoringTodo, format);


### PR DESCRIPTION
정상적이지 않은 값을 사용해 리팩토링 된 코드 등록을 요청하는 경우 글이 등록되지 않고 예외를 던지도록 만드는 요구사항을 tdd 방식으로 구현합니다.

* 존재하지 않는 리팩토링 대상 코드의 아이디를 가지고 등록 요청을 할 때,비즈니스 로직인 saveRefactoringDone 메소드에서 리포지토리를 이용해 refactoringTodo를 찾을 수 없고, 이 때 IllegalArgumentException 예외를 던지도록 설계하였습니다.

* 리팩토링 코드가 10,000자를 초과하거나, 코드 설명이 1,000자를 넘어가면 클라이언트에서 컨트롤러로 넘어올 때 validation에 잘 걸리는 지 테스트하고 spring-boot-starter-validation 라이브러리를 이용해 구현했습니다. 본래 컨트롤러 테스트에서 검증하는 것이 더 적합하지만, 이러한 제약사항이 있다라는 것을 비즈니스 로직에서도 알 수 있도록 명시하기 위해 테스트코드로 작성해 두었습니다.