### PR TITLE
#63 - 리팩토링 한 코드 좋아요 등록 비즈니스 로직 tdd로 구현하기

### DIFF
--- a/src/main/java/com/refactoring/refactoringproject/entity/Liked.java
+++ b/src/main/java/com/refactoring/refactoringproject/entity/Liked.java
@@ -1,8 +1,15 @@
 package com.refactoring.refactoringproject.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Liked {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/refactoring/refactoringproject/repository/LikedRepository.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/LikedRepository.java
@@ -1,0 +1,13 @@
+package com.refactoring.refactoringproject.repository;
+
+import com.refactoring.refactoringproject.entity.Liked;
+import com.refactoring.refactoringproject.entity.Member;
+import com.refactoring.refactoringproject.entity.RefactoringDone;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikedRepository extends JpaRepository<Liked, Long> {
+    Optional<Liked> findByMemberAndRefactoringDone(Member member, RefactoringDone refactoringDone);
+}

--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringDoneService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringDoneService.java
@@ -2,8 +2,11 @@ package com.refactoring.refactoringproject.service;
 
 import com.refactoring.refactoringproject.dto.RefactoringDoneFormat;
 import com.refactoring.refactoringproject.dto.RefactoringDoneResponse;
+import com.refactoring.refactoringproject.entity.Liked;
+import com.refactoring.refactoringproject.entity.Member;
 import com.refactoring.refactoringproject.entity.RefactoringDone;
 import com.refactoring.refactoringproject.entity.RefactoringTodo;
+import com.refactoring.refactoringproject.repository.LikedRepository;
 import com.refactoring.refactoringproject.repository.RefactoringDoneRepository;
 import com.refactoring.refactoringproject.repository.RefactoringTodoRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import java.util.Optional;
 public class RefactoringDoneService {
     private final RefactoringDoneRepository refactoringDoneRepository;
     private final RefactoringTodoRepository refactoringTodoRepository;
+    private final LikedRepository likedRepository;
 
     public Long saveRefactoringDone(RefactoringDoneFormat format) {
         Optional<RefactoringTodo> refactoringTodoOptional = refactoringTodoRepository.findById(format.getRefactoringTodoId());
@@ -35,5 +39,21 @@ public class RefactoringDoneService {
         Optional<RefactoringDone> resultOptional = this.refactoringDoneRepository.findById(refactoringDoneId);
         RefactoringDone refactoringDone = resultOptional.orElseThrow(() -> new EmptyResultDataAccessException("there is no RefactoringDone with id " + refactoringDoneId, 1));
         return RefactoringDoneResponse.from(refactoringDone);
+    }
+
+    public void assignLike(Member member, Long refactoringDoneId) {
+        Optional<RefactoringDone> refactoringDoneOptional = this.refactoringDoneRepository.findById(refactoringDoneId);
+        RefactoringDone refactoringDone = refactoringDoneOptional.orElseThrow(() -> new IllegalArgumentException("you tried to post a Like for RefactoringDone which is not existing"));
+
+        if (this.likedRepository.findByMemberAndRefactoringDone(member, refactoringDone).isPresent()) {
+            throw new IllegalArgumentException("You can't post like to RefactoringDone you already posted");
+        }
+
+        if (refactoringDone.getMember().equals(member)) {
+            throw new IllegalArgumentException("You can't post like to RefactoringDone written by yourself");
+        }
+
+        Liked liked = new Liked(null, member, refactoringDone);
+        likedRepository.save(liked);
     }
 }


### PR DESCRIPTION
리팩토링 대상 코드에 추가/삭제할 수 있는 즐겨찾기 기능과 비슷하게, 리팩토링 한 코드 게시글에 좋아요를 등록할 수 있는 비즈니스 로직을 tdd로 테스트 후에 구현합니다.

* refactoringDoneService.assignlike() 를 호출하여 특정 리팩토링 한 코드 게시글을 좋아요하는 시나리오를 생각해본 후, 테스트 코드에 해당 시나리오를 작성했습니다. 이후 실제로 구현하는 과정에서 Liked 데이터베이스에 접근하기 위해 JpaRepository를 상속한 LikedRepository 인터페이스를 만들고, 비즈니스 로직 내부에 save메소드로 Liked 하나를 저장하는 간단한 로직으로 구현을 완료했습니다.

* '같은 리팩토링 한 코드 게시글을 두 번 이상 좋아요 누를 수 없다' 와 '자신이 작성한 리팩토링 한 코드 게시글을 좋아요 등록할 수 없다' 라는 제약사항을 구현하기 위해 오류 시나리오를 테스트코드에 추가하고, 해당 테스트 코드가 성공하도록 비즈니스 로직에 제약사항을 반영한 if문 코드를 작성했습니다.