### PR TITLE
#65 - 리팩토링 된 코드 좋아요 삭제 비즈니스 로직 tdd로 테스트하고 구현하기

### DIFF
--- a/src/main/java/com/refactoring/refactoringproject/repository/LikedRepository.java
+++ b/src/main/java/com/refactoring/refactoringproject/repository/LikedRepository.java
@@ -5,9 +5,10 @@ import com.refactoring.refactoringproject.entity.Member;
 import com.refactoring.refactoringproject.entity.RefactoringDone;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface LikedRepository extends JpaRepository<Liked, Long> {
     Optional<Liked> findByMemberAndRefactoringDone(Member member, RefactoringDone refactoringDone);
+
+    Optional<Liked> findByMemberAndRefactoringDone_Id(Member member, Long refactoringDoneId);
 }

--- a/src/main/java/com/refactoring/refactoringproject/service/RefactoringDoneService.java
+++ b/src/main/java/com/refactoring/refactoringproject/service/RefactoringDoneService.java
@@ -56,4 +56,11 @@ public class RefactoringDoneService {
         Liked liked = new Liked(null, member, refactoringDone);
         likedRepository.save(liked);
     }
+
+    public void deleteLike(Member member, Long refactoringDoneId) {
+        Optional<Liked> likeOptional = this.likedRepository.findByMemberAndRefactoringDone_Id(member, refactoringDoneId);
+        Liked liked = likeOptional.orElseThrow(() -> new IllegalArgumentException("You may not have posted like on this RefactoringDone"));
+
+        this.likedRepository.delete(liked);
+    }
 }


### PR DESCRIPTION
등록된 좋아요를 삭제하는 비즈니스 로직을 tdd로 테스트함과 동시에 구현합니다.

* refactoringDoneService.deleteLike() 메소드에 어떤 값을 넘겨서 좋아요 삭제를 진행할 지 시나리오를 생각해본 후 해당 시나리오를 테스트코드에 반영했습니다. 지금의 비즈니스 로직은 리팩토링 된 코드 조회 화면에서, 좋아요 버튼을 한 번 눌러 좋아요 등록이 된 상태에서 또 한번 눌렀을 때의 시나리오를 생각한 것입니다.

* 메소드명만으로 쿼리를 유추해 생성하는 Sprind Data Jpa의 유용한 기능을 이용해 내가 등록한 좋아요를 찾아낸 후, 삭제하는 간단한 로직으로 구현을 완료했습니다.

* 조회된 Liked 객체가 Optional이므로 객체 조회가 안되어 내부가 비어있을 경우의 예외 처리를 쉽게 할 수 있었습니다.

This closes #65 